### PR TITLE
Backport build-id debuglink test fixes from 2.41-branch.

### DIFF
--- a/binutils/testsuite/binutils-all/objdump.exp
+++ b/binutils/testsuite/binutils-all/objdump.exp
@@ -277,30 +277,29 @@ proc test_build_id_debuglink {} {
     global srcdir
     global subdir
     global env
-    global CC_FOR_TARGET
     global STRIP
     global OBJCOPY
     global OBJDUMP
     global CFLAGS_FOR_TARGET
     
     set test "build-id-debuglink"
-    if {![info exists CC_FOR_TARGET]} {
-	set CC_FOR_TARGET $env(CC)
-    }
-    if { $CC_FOR_TARGET == "" } {
-	unsupported $test
-	return
-    }
 
     # Use a fixed build-id.
+    if { [info exists CFLAGS_FOR_TARGET] } {
+	set save_CFLAGS_FOR_TARGET $CFLAGS_FOR_TARGET
+    }
     set CFLAGS_FOR_TARGET "-g -Wl,--build-id=0x12345678abcdef01"
 
-    if { [target_compile $srcdir/$subdir/testprog.c tmpdir/testprog exectuable debug] != "" } {
-	fail "$test (build)"
+    if { [target_compile $srcdir/$subdir/testprog.c tmpdir/testprog executable debug] != "" } {
+	unsupported "$test (build)"
 	return
     }
 
-    # FIXME: Do we need to restore CFLAGS_FOR_TARGET to its old value ?
+    if { [info exists save_CFLAGS_FOR_TARGET] } {
+	set CFLAGS_FOR_TARGET $save_CFLAGS_FOR_TARGET
+    } else {
+	unset CFLAGS_FOR_TARGET
+    }
 
     if { [binutils_run $STRIP "--strip-debug --remove-section=.comment tmpdir/testprog -o tmpdir/testprog.strip"] != "" } {
 	fail "$test (strip debug info)"
@@ -350,7 +349,7 @@ proc test_build_id_debuglink {} {
     }
 }
 
-if {[isnative] && [is_elf_format]} then {
+if {[is_elf_format]} then {
     test_build_id_debuglink
 }
 


### PR DESCRIPTION
commit 2ecde2b63245d4794a4967f318772e7166feb310
Author: Matthew Malcomson <matthew.malcomson@arm.com>
Date:   Wed May 1 16:52:51 2019 +0100

    Fix spelling mistakes in binutils testsuite.

	* testsuite/binutils-all/objdump.exp: Correct executable spelling.

commit 0034eed03a7428c4902244a33a286763bca65016
Author: Alan Modra <amodra@gmail.com>
Date:   Tue May 29 10:53:18 2018 +0930

    Run a few more binutils tests non-native

    Setting CC_FOR_TARGET from the environment CC was just plain wrong,
    and no doubt the reason these tests were only run natively.

	* testsuite/binutils-all/objdump.exp (test_build_id_debuglink): Don't set CC_FOR_TARGET.  Run test non-native.

commit bb3b5316332875b436b4a88d1ec6968eba46a870
Author: Alan Modra <amodra@gmail.com>
Date:   Mon May 28 16:30:23 2018 +0930

    PR23235, make check uses system installed ld

    This patch doesn't stop the build-id and debuglink tests using the
    installed ld, it just prevents a compiler failure from resulting in a
    test fail.  We could move the tests to the ld testsuite but it doesn't
    seem all that important.

	PR 23235
        * testsuite/binutils-all/objdump.exp (test_build_id_debuglink): Return
	unsupported rather than fail on compile errors.  Save and restore
	CFLAGS_FOR_TARGET.